### PR TITLE
Server kits in repository hosted on GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 PKGBUILD
 pkg/
 src/
+repo/
+gh-pages/

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,36 @@ $(addprefix uninstall-,$(KITS)): uninstall-%:
 
 .PHONY: install-all
 install-all: $(addprefix install-,$(KITS))
+
+GPGKEY ?= 69F8E5E5E85F771020A0777C3D309011083BA25E
+REPO_ADD_ARGS ?= --sign --include-sigs --new --remove --key $(GPGKEY)
+REPONAME = kits
+
+.PHONY: create-gh-pages-branch
+gh-pages-create-branch:
+	git show-ref --quiet refs/heads/gh-pages || { \
+		git checkout --orphan gh-pages; \
+		git reset --hard; \
+		git commit --allow-empty -m "Initial commit"; \
+		git checkout main; \
+	}
+	git worktree add gh-pages || :
+	repo-add $(REPO_ADD_ARGS) gh-pages/$(REPONAME).db.tar.gz
+	git -C gh-pages add '$(REPONAME).*'
+	git -C gh-pages diff --quiet --cached || \
+		git -C gh-pages commit -m "Add empty repo database"
+
+PKGVER = $(shell git describe --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g')
+PKGFILES = $(foreach kit,$(KITS),kits/$(kit)/$(kit)-$(PKGVER)-1-any.pkg.tar.zst)
+
+.PHONY: gh-pages-stage-packages
+gh-pages-stage-packages: $(PKGFILES)
+	install -Dm644 -t gh-pages $^ $(addsuffix .sig,$^)
+	repo-add $(REPO_ADD_ARGS) gh-pages/$(REPONAME).db.tar.gz $^
+	./mk/gen-index-html gh-pages > gh-pages/index.html
+	git -C gh-pages add '*'
+	git -C gh-pages commit -m "upgpkg: $(PKGVER)"
+
+.PHONY: gh-pages-push-packages
+gh-pages-push-packages:
+	git -C gh-pages push origin gh-pages

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 KITS = $(notdir $(shell find kits -mindepth 1 -maxdepth 1 -type d))
 
+.PHONY: $(addprefix package-signed-,$(KITS))
+$(addprefix package-signed-,$(KITS)): package-signed-%:
+	@$(MAKE) -C kits/$* package-signed
+
+.PHONY: package-signed-all
+package-signed-all: $(addprefix package-signed-,$(KITS))
+
 .PHONY: $(addprefix install-,$(KITS))
 $(addprefix install-,$(KITS)): install-%:
 	@$(MAKE) -C kits/$* install

--- a/mk/gen-index-html
+++ b/mk/gen-index-html
@@ -1,0 +1,29 @@
+#!/bin/sh -eu
+
+dir=${1:?}
+
+cat << EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Repository Index</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+  <h1>Repository Index</h1>
+  <ul>
+EOF
+
+find "$dir" -type f -not -path '*/.*' \
+  | LC_ALL=C sort \
+  | while IFS= read -r abs_path; do
+    rel_path=${abs_path#"$dir"/}
+    printf '    <li><a href="%s">%s</a></li>\n' "$rel_path" "$rel_path"
+  done
+
+cat << EOF
+  </ul>
+</body>
+</html>
+EOF

--- a/mk/kit.mk
+++ b/mk/kit.mk
@@ -30,6 +30,9 @@ $(PKGFILE).sig: archive PKGBUILD
 .PHONY: package
 package: $(PKGFILE)
 
+.PHONY: package-signed
+package-signed: $(PKGFILE).sig
+
 .PHONY: install
 install: $(PKGFILE)
 	sudo pacman -U $<

--- a/mk/kit.mk
+++ b/mk/kit.mk
@@ -35,4 +35,4 @@ uninstall:
 
 .PHONY: clean
 clean:
-	rm -rf *.pkg.tar.zst *.tar.gz PKGBUILD pkg/ src/
+	rm -rf ./*.pkg.tar.zst ./*.tar.gz ./PKGBUILD ./pkg/ ./src/

--- a/mk/kit.mk
+++ b/mk/kit.mk
@@ -2,6 +2,8 @@ ifeq ($(PKGNAME),)
   $(error PKGNAME is not defined)
 endif
 
+MAKEPKG_ARGS ?= --syncdeps --noconfirm
+
 PKGVER = $(shell git describe --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g')
 ARCHIVE = $(PKGNAME)-$(PKGVER).tar.gz
 PKGFILE = $(PKGNAME)-$(PKGVER)-1-any.pkg.tar.zst
@@ -20,7 +22,10 @@ PKGBUILD: PKGBUILD.in
 	sed -e 's/@PKGVER@/$(PKGVER)/' PKGBUILD.in > PKGBUILD
 
 $(PKGFILE): archive PKGBUILD
-	test -f $@ || makepkg --syncdeps
+	test -f $@ || makepkg $(MAKEPKG_ARGS)
+
+$(PKGFILE).sig: archive PKGBUILD
+	test -f $@ || makepkg $(MAKEPKG_ARGS) --force --sign
 
 .PHONY: package
 package: $(PKGFILE)


### PR DESCRIPTION
Adds the following make targets for publishing packages to a repository GitHub
pages:

1. gh-pages-create-branch: Creates the branch gh-pages if it doesn't exist.
   Checks it out in a worktree at ./gh-pages and add a repository database.

2. gh-pages-stage-packages: Copies signed packages to the gh-pages worktree,
   updates the repository database, generates an index HTML file and commits
   the changes.

3. gh-pages-push-packages: Pushed the changes to gh-pages.