### PR TITLE
kit-base-system: Migrate LUKS unlock to sd-encrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/
 src/
 repo/
 gh-pages/
+.mkincl/providers/

--- a/.mkincl/init.mk
+++ b/.mkincl/init.mk
@@ -1,0 +1,17 @@
+MKINCL_DIR ?= .mkincl
+INITS = $(wildcard $(MKINCL_DIR)/inits/*)
+
+.PHONY: init-mkincl $(INITS)
+init-mkincl: clean-mkincl $(INITS)
+$(INITS):
+	@echo -- Initializing provider $@
+	. $(realpath $@) \
+	&& mkdir -p $(MKINCL_DIR)/providers \
+	&& git clone --quiet $$URL $(MKINCL_DIR)/providers/$$NAME \
+	&& git -C $(MKINCL_DIR)/providers/$$NAME reset --quiet --hard $$VERSION
+
+.PHONY: clean-mkincl
+clean-mkincl:
+	rm -rf $(MKINCL_DIR)/providers
+
+-include $(MKINCL_DIR)/providers/*/include.mk

--- a/.mkincl/inits/shell.sh
+++ b/.mkincl/inits/shell.sh
@@ -1,0 +1,3 @@
+export NAME=shell
+export VERSION=v1
+export URL=https://github.com/mkincl/shell-provider

--- a/.mkincl/inits/shell.sh
+++ b/.mkincl/inits/shell.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 export NAME=shell
 export VERSION=v1
 export URL=https://github.com/mkincl/shell-provider

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include .mkincl/init.mk
+
 KITS = $(notdir $(shell find kits -mindepth 1 -maxdepth 1 -type d))
 
 .PHONY: $(addprefix package-signed-,$(KITS))

--- a/kits/kit-base-system/PKGBUILD.in
+++ b/kits/kit-base-system/PKGBUILD.in
@@ -18,6 +18,7 @@ sha256sums=('SKIP')
 
 package() {
   cd $pkgname-$pkgver
+  install -vDm644 -t "$pkgdir/etc/mkinitcpio.conf.d" files/10-sd-encrypt.conf
   install -vDm644 -t "$pkgdir/etc/systemd/network" files/20-wired.network
   install -vDm644 -t "$pkgdir/etc/systemd/network" files/25-wireless.network
   install -vDm644 -t "$pkgdir/etc/udev/rules.d" files/99-usb-root-hub-wakeup.rules

--- a/kits/kit-base-system/PKGBUILD.in
+++ b/kits/kit-base-system/PKGBUILD.in
@@ -15,6 +15,7 @@ depends=(
 )
 source=("$pkgname-$pkgver.tar.gz")
 sha256sums=('SKIP')
+install=$pkgname.install
 
 package() {
   cd $pkgname-$pkgver
@@ -22,6 +23,8 @@ package() {
   install -vDm644 -t "$pkgdir/etc/systemd/network" files/20-wired.network
   install -vDm644 -t "$pkgdir/etc/systemd/network" files/25-wireless.network
   install -vDm644 -t "$pkgdir/etc/udev/rules.d" files/99-usb-root-hub-wakeup.rules
+  install -vDm644 -t "$pkgdir/usr/lib/$pkgname" files/crypttab.initramfs.in
+  install -vDm755 -t "$pkgdir/usr/lib/$pkgname" files/render-crypttab-initramfs
 
   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
 }

--- a/kits/kit-base-system/files/10-sd-encrypt.conf
+++ b/kits/kit-base-system/files/10-sd-encrypt.conf
@@ -1,0 +1,6 @@
+# Replace the HOOKS array from /etc/mkinitcpio.conf with a systemd-based
+# initramfs that unlocks LUKS via sd-encrypt and reads /etc/crypttab.initramfs.
+# The keyboard hook is placed before autodetect so USB-HID modules are always
+# included, allowing passphrase entry on any attached keyboard (internal,
+# external, docked).
+HOOKS=(base systemd keyboard autodetect microcode modconf kms sd-vconsole block sd-encrypt lvm2 filesystems fsck)

--- a/kits/kit-base-system/files/crypttab.initramfs.in
+++ b/kits/kit-base-system/files/crypttab.initramfs.in
@@ -1,0 +1,3 @@
+# Rendered to /etc/crypttab.initramfs by
+# /usr/lib/kit-base-system/render-crypttab-initramfs.
+%NAME% UUID=%UUID% none luks,discard,no-read-workqueue,no-write-workqueue

--- a/kits/kit-base-system/files/render-crypttab-initramfs
+++ b/kits/kit-base-system/files/render-crypttab-initramfs
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Render /etc/crypttab.initramfs from the active LUKS2 mapping using the
+# template at /usr/lib/kit-base-system/crypttab.initramfs.in. Always
+# overwrites the target so kit updates to the template take effect on
+# package upgrade. Skips only if zero or multiple LUKS2 mappings are
+# active (ambiguous source).
+
+set -euo pipefail
+
+argv0=render-crypttab-initramfs
+target=/etc/crypttab.initramfs
+template=/usr/lib/kit-base-system/crypttab.initramfs.in
+
+log() {
+  local fmt=$1
+  shift
+  # shellcheck disable=SC2059
+  printf "%s: $fmt\n" "$argv0" "$@" >&2
+}
+
+mappings=()
+for f in /sys/class/block/dm-*/dm/uuid; do
+  [[ -r $f ]] || continue
+  IFS= read -r entry < "$f"
+  if [[ $entry =~ ^CRYPT-LUKS2-([0-9a-f]+)-(.+)$ ]]; then
+    mappings+=("${BASH_REMATCH[2]}:${BASH_REMATCH[1]}")
+  fi
+done
+
+case ${#mappings[@]} in
+0)
+  log 'no active LUKS2 mapping found, skipping %s' "$target"
+  exit 0
+  ;;
+1) ;;
+*)
+  log 'multiple LUKS2 mappings active, cannot auto-pick:'
+  printf '  %s\n' "${mappings[@]}" >&2
+  log 'create %s manually' "$target"
+  exit 0
+  ;;
+esac
+
+name=${mappings[0]%%:*}
+uuid_raw=${mappings[0]##*:}
+uuid=${uuid_raw:0:8}-${uuid_raw:8:4}-${uuid_raw:12:4}-${uuid_raw:16:4}-${uuid_raw:20:12}
+
+verb=wrote
+[[ -e $target ]] && verb=overwrote
+
+umask 077
+sed \
+  -e "s|%NAME%|${name}|g" \
+  -e "s|%UUID%|${uuid}|g" \
+  "$template" > "$target"
+chmod 600 "$target"
+
+log '%s %s for mapping=%s uuid=%s' "$verb" "$target" "$name" "$uuid"
+log 'run mkinitcpio -P and reboot to apply'

--- a/kits/kit-base-system/kit-base-system.install
+++ b/kits/kit-base-system/kit-base-system.install
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+
+post_install() {
+  /usr/lib/kit-base-system/render-crypttab-initramfs
+}
+
+post_upgrade() {
+  /usr/lib/kit-base-system/render-crypttab-initramfs
+}

--- a/kits/kit-secrets/files/pinentry-preexec.sh
+++ b/kits/kit-secrets/files/pinentry-preexec.sh
@@ -1,1 +1,2 @@
+# shellcheck shell=bash
 exec /usr/bin/pinentry-tty "$@"


### PR DESCRIPTION
Enables packaging the LUKS perf options `no-read-workqueue` and `no-write-workqueue` for this machine's encrypted setup. These flags are the dominant fix for multi-second `w_await` spikes during heavy writes (podman commits, pacman installs) on LUKS-backed NVMe — but they can only be applied through `sd-encrypt`'s `/etc/crypttab.initramfs`, not via the busybox `encrypt` hook's `cryptdevice=` cmdline argument. Switching the initramfs hook is therefore a prerequisite.

Two kit-base-system additions ship together:

- `/etc/mkinitcpio.conf.d/10-sd-encrypt.conf` — HOOKS drop-in replacing the busybox-based array with the systemd-based equivalent. Uses mkinitcpio 41+'s drop-in mechanism so the main `/etc/mkinitcpio.conf` keeps its machine-specific `MODULES`/`BINARIES`/`COMPRESSION` lines untouched. `keyboard` is moved before `autodetect` so the initramfs always carries USB-HID modules, not just whatever keyboard was attached at generation time.

- A renderer-and-template pair for `/etc/crypttab.initramfs`. The kit ships `/usr/lib/kit-base-system/crypttab.initramfs.in` with `%NAME%` / `%UUID%` placeholders and `/usr/lib/kit-base-system/render-crypttab-initramfs` which discovers the active LUKS2 mapping from `/sys/class/block/dm-*/dm/uuid`, sed-substitutes, and writes mode-0600 output. The `.install` scriptlet invokes the renderer on `post_install` and `post_upgrade`. Always overwrites — kit is the source of truth for the options. The script is also usable standalone with `sudo /usr/lib/kit-base-system/render-crypttab-initramfs`.

What stays manual on the host operator: bootloader cmdline rewrite (`cryptdevice=…` → `rd.luks.name=…`), `mkinitcpio -P`, and reboot. Those touch `/boot` (FAT32, not pacman-tracked) and are inherently per-machine.

Measured impact after the migration on the originating arc-fpa podman build workload, median of 3 runs invalidating only the final RUN of an otherwise warm-cached build:

| Metric | Before | After |
|---|---|---|
| Build wall time (median) | 48.6 s | 15.8 s |
| Peak `w_await` on nvme0n1 | 6456 ms | 10–187 ms |
| Average `%iowait` across CPUs | 22.4 % | 0.7–2.9 % |

The branch also brings in a shell lint provider via `.mkincl` and a shellcheck-warning sweep across existing scripts — infrastructure the renderer relies on for `make lint-shell` / `make fix-shell`.

An alpm hook to auto-rebuild initramfs on changes to the drop-in or template was prototyped and intentionally left out for now to keep the moving parts visible; can be added later when the manual `mkinitcpio -P` step starts feeling like a chore.