### PR TITLE
Render fstab from a kit template with lazytime + data=writeback on /home

### DIFF
--- a/kits/kit-base-system/PKGBUILD.in
+++ b/kits/kit-base-system/PKGBUILD.in
@@ -33,7 +33,9 @@ package() {
   install -vDm644 files/oomd-user-service.conf \
     "$pkgdir/etc/systemd/system/user@.service.d/99-oomd.conf"
   install -vDm644 -t "$pkgdir/usr/lib/$pkgname" files/crypttab.initramfs.in
+  install -vDm644 -t "$pkgdir/usr/lib/$pkgname" files/fstab.in
   install -vDm755 -t "$pkgdir/usr/lib/$pkgname" files/render-crypttab-initramfs
+  install -vDm755 -t "$pkgdir/usr/lib/$pkgname" files/render-fstab
 
   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
 }

--- a/kits/kit-base-system/files/fstab.in
+++ b/kits/kit-base-system/files/fstab.in
@@ -1,0 +1,14 @@
+# Rendered to /etc/fstab by /usr/lib/kit-base-system/render-fstab.
+# See fstab(5) for details.
+
+# /dev/mapper/VolGroup-root
+UUID=%ROOT_UUID%	/         	ext4      	rw,relatime,lazytime	0 1
+
+# /dev/mapper/VolGroup-home
+UUID=%HOME_UUID%	/home     	ext4      	rw,relatime,lazytime,data=writeback	0 2
+
+# ESP (typically /dev/nvme0n1p1)
+UUID=%BOOT_UUID%	/boot     	vfat      	rw,relatime,fmask=0177,dmask=0077,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro	0 2
+
+# /dev/mapper/VolGroup-swap
+UUID=%SWAP_UUID%	none      	swap      	defaults	0 0

--- a/kits/kit-base-system/files/render-fstab
+++ b/kits/kit-base-system/files/render-fstab
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Render /etc/fstab from the active filesystem layout using the template at
+# /usr/lib/kit-base-system/fstab.in. Discovers UUIDs for the LUKS+LVM layout
+# this kit assumes: VolGroup with root/home/swap LVs and a vfat ESP at /boot.
+# Always overwrites the target so template changes propagate on package
+# upgrade. Skips only if any expected source is missing (ambiguous host).
+
+set -euo pipefail
+
+argv0=render-fstab
+target=/etc/fstab
+template=/usr/lib/kit-base-system/fstab.in
+
+log() {
+  local fmt=$1
+  shift
+  # shellcheck disable=SC2059
+  printf "%s: $fmt\n" "$argv0" "$@" >&2
+}
+
+declare -A uuid
+uuid[ROOT]=$(lsblk -no UUID /dev/mapper/VolGroup-root 2>/dev/null || true)
+uuid[HOME]=$(lsblk -no UUID /dev/mapper/VolGroup-home 2>/dev/null || true)
+uuid[SWAP]=$(lsblk -no UUID /dev/mapper/VolGroup-swap 2>/dev/null || true)
+uuid[BOOT]=$(findmnt -no UUID /boot 2>/dev/null || true)
+
+missing=()
+for k in ROOT HOME SWAP BOOT; do
+  [[ -n ${uuid[$k]:-} ]] || missing+=("$k")
+done
+
+if (( ${#missing[@]} > 0 )); then
+  log 'cannot discover UUID for: %s' "${missing[*]}"
+  log 'leaving %s untouched' "$target"
+  exit 0
+fi
+
+tmp=$(mktemp /etc/fstab.XXXXXX)
+trap 'rm -f "$tmp"' EXIT
+
+sed \
+  -e "s|%ROOT_UUID%|${uuid[ROOT]}|g" \
+  -e "s|%HOME_UUID%|${uuid[HOME]}|g" \
+  -e "s|%BOOT_UUID%|${uuid[BOOT]}|g" \
+  -e "s|%SWAP_UUID%|${uuid[SWAP]}|g" \
+  "$template" > "$tmp"
+
+if grep -q '%[A-Z_]*%' "$tmp"; then
+  log 'unsubstituted placeholders remain in rendered fstab, refusing to write'
+  exit 1
+fi
+
+if ! findmnt --verify --tab-file "$tmp" >/dev/null; then
+  log 'findmnt --verify rejected the rendered fstab, refusing to write'
+  findmnt --verify --tab-file "$tmp" >&2 || true
+  exit 1
+fi
+
+verb=wrote
+[[ -e $target ]] && verb=overwrote
+
+chmod 644 "$tmp"
+mv -f "$tmp" "$target"
+trap - EXIT
+
+# Bake data=writeback into the home ext4 superblock as the default mount
+# option, so the preference survives if fstab is ever mis-edited or the
+# filesystem is mounted from a recovery shell.
+tune2fs -o +journal_data_writeback /dev/mapper/VolGroup-home >/dev/null
+
+log '%s %s' "$verb" "$target"
+log 'lazytime takes effect after: sudo mount -o remount /home /'
+log 'data=writeback takes effect at next boot (or full umount+mount cycle)'

--- a/kits/kit-base-system/kit-base-system.install
+++ b/kits/kit-base-system/kit-base-system.install
@@ -2,6 +2,7 @@
 
 post_install() {
   /usr/lib/kit-base-system/render-crypttab-initramfs
+  /usr/lib/kit-base-system/render-fstab
 
   echo "To enable systemd-oomd, run:"
   echo ""
@@ -17,4 +18,5 @@ post_install() {
 
 post_upgrade() {
   /usr/lib/kit-base-system/render-crypttab-initramfs
+  /usr/lib/kit-base-system/render-fstab
 }


### PR DESCRIPTION
Heavy multi-writer workloads on this stack (LUKS+LVM+ext4 NVMe, several concurrent writers from browser/editor/claude/pip-install) hit visible desktop freezes because ext4's default ordered-data journaling serializes journal commits behind outstanding data writes. The Fix-1 dmcrypt-no-workqueue change addressed disk dispatch but not the journal-vs-data ordering, so under concurrent load `jbd2` parks in `D` state and every fsync chain in the system queues behind it.

Captured live during one such episode:

- `jbd2/dm-3-8` in `D` state (`io_schedule`).
- `/proc/pressure/io`: `some avg10=70 avg60=64` — processes stalled on I/O ~65 % of the time at idle.
- 1 GB pending dirty pages, 17 MB actively in writeback, disk doing 13–47 MB/s of actual writes. Throughput-bound on serialization, not bandwidth.
- `w_await` peaks 146–183 ms despite Fix 1 being active.

This PR adopts the kit's existing template-render pattern (mirroring `render-crypttab-initramfs`) to manage `/etc/fstab`. The render script discovers UUIDs deterministically from the standard layout this kit assumes (LUKS+LVM with `VolGroup` holding root/home/swap LVs plus a vfat ESP at `/boot`) and substitutes them into `fstab.in`. If any expected UUID can't be discovered, the script logs and leaves fstab untouched — same behavior the crypttab renderer uses for ambiguous hosts.

The changes the rendered fstab applies:

- `/` and `/home` get `lazytime` — defers atime/mtime/ctime updates so metadata-heavy workloads (e.g. extracting thousands of wheel files) stop triggering a journal commit per file. Near-zero risk; the only crash-time impact is stale timestamps.
- `/home` gets `data=writeback` — decouples journal commits from data flushes, which is the chain that produces the stalls observed above. Confined to `/home` rather than `/` because `/home` is reproducible dev state (worst case after crash: `pip install --force-reinstall`, `git fsck`) while `/` is system files with higher consequence per crash-corrupted write.
- Root keeps default ordered data; this is intentional, not an oversight.

The script also runs `tune2fs -o +journal_data_writeback` on the home device so the writeback default lives in the ext4 superblock too. If `/etc/fstab` is ever mis-edited or `/home` is mounted from a recovery shell, the FS still mounts with the right journaling mode.

Validation in the render script before overwriting `/etc/fstab`:

- All four expected UUIDs must be discoverable; missing any aborts cleanly.
- Rendered file must have no unsubstituted `%PLACEHOLDER%` markers.
- `findmnt --verify --tab-file` must accept the rendered file.
- Final write is atomic via `mktemp` + `mv`.

Tested on this machine via the dry-run path (sed substitution against the live UUIDs and diff against `/etc/fstab`) — output matches what we'd want exactly, no spurious changes. Applying for real requires a reboot or full umount/remount cycle on `/home` since `data=` is set at mount time.

A reasonable next step (not in this PR) is to add UUID-resolution and mountpoint-existence pre-flight checks before the swap. Deferred for now since the four-UUID structural shape is well-validated by `findmnt --verify` and the discovery itself only succeeds when the devices already resolve.